### PR TITLE
chore(seo): add IndexNow and growth follow-up

### DIFF
--- a/docs/seo/2026-04-28-growth-priority-pages.md
+++ b/docs/seo/2026-04-28-growth-priority-pages.md
@@ -1,0 +1,22 @@
+# AIPromptIndex Growth Priorities
+
+Updated: 2026-04-28
+
+## Priority Pages
+
+These pages should receive the next internal-link and citation/backlink pass because Ahrefs technical health is now 100 but visibility remains the larger constraint.
+
+| Page | Primary angle | Internal anchor text | Citation/backlink target |
+| --- | --- | --- | --- |
+| `/` | Free AI prompt library for multiple tools | AI prompt library, free prompt library | Directory listings, founder profiles, AI workflow resources |
+| `/prompts/` | Browseable AI prompt catalog | AI prompt catalog, free prompt templates | Prompt-resource lists, tool roundup companion links |
+| `/best/free-ai-prompts/` | Free prompt collection for users not ready to pay | free AI prompt library, free AI prompts | Free resource directories, creator/student resource lists |
+| `/best/best-ai-prompts/` | Strongest prompt examples across the site | best AI prompt catalog, best AI prompts | AI newsletter citations, curated productivity resources |
+| `/blog/how-to-write-ai-prompts-beginners-guide/` | Beginner education support page | how to write AI prompts, prompt engineering guide | Beginner AI guides, classroom/workshop references |
+
+## Next Link-Building Motions
+
+- Add citations from owned profiles and resource pages to `/prompts/` and `/best/free-ai-prompts/`.
+- Pitch `/blog/how-to-write-ai-prompts-beginners-guide/` as a beginner reference when discussing AI literacy, education, and creator workflows.
+- Use `/best/best-ai-prompts/` as the destination for broad "best prompts" citations and `/best/free-ai-prompts/` for free-resource citations.
+- Keep internal links using descriptive anchors, not generic "click here" text.

--- a/docs/seo/2026-04-28-slow-page-triage.md
+++ b/docs/seo/2026-04-28-slow-page-triage.md
@@ -1,0 +1,20 @@
+# Ahrefs Slow Page Triage
+
+Updated: 2026-04-28
+
+Ahrefs flagged three slow pages after the confirmation crawl:
+
+| Page | Ahrefs issue | Live follow-up result |
+| --- | --- | --- |
+| `/tools/cursor/` | Slow page | Three live `curl` checks returned `0.481s`, `0.235s`, and `0.203s` total load time. |
+| `/best/chatgpt-prompts/` | Slow page | Three live `curl` checks returned `0.444s`, `0.185s`, and `0.190s` total load time. |
+| `/prompts/investor-update-email/` | Slow page | Three live `curl` checks returned `0.477s`, `0.792s`, and `0.201s` total load time. |
+
+## Assessment
+
+The follow-up measurements do not reproduce a persistent server-side slowdown. The Ahrefs warning looks like transient edge response variance, with `/best/chatgpt-prompts/` carrying the largest HTML payload and `/prompts/investor-update-email/` showing one slower repeat.
+
+## Follow-Up
+
+- Recheck after the next Ahrefs crawl before making performance-specific source changes.
+- If the same pages are repeatedly flagged, prioritize reducing repeated prompt-card markup on large collection pages and reviewing client-side islands on prompt detail pages.

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "seo:verify:live": "node scripts/seo/verify-live.mjs",
     "seo:verify:ga4-live": "node scripts/seo/verify-ga4-live.mjs",
     "seo:verify:all": "npm run seo:verify:setup && npm run seo:verify:live",
+    "seo:submit:indexnow": "node scripts/seo/submit-indexnow.mjs",
     "seo:pull:daily": "npm run seo:pull:ahrefs && npm run seo:pull:ahrefs-site-audit -- --mode=overview && npm run seo:pull:ahrefs-rank-tracker && npm run seo:pull:gsc && npm run seo:pull:ga4 && npm run seo:brief && npm run syndicate:medium",
     "seo:pull:weekly": "npm run seo:pull:ahrefs && npm run seo:pull:ahrefs-keywords-explorer && npm run seo:pull:ahrefs-backlinks-deep && npm run seo:pull:ahrefs-site-audit -- --mode=full && npm run seo:pull:brand-radar",
     "seo:pull:monthly": "npm run seo:pull:ahrefs-batch-analysis",

--- a/scripts/seo/submit-indexnow.mjs
+++ b/scripts/seo/submit-indexnow.mjs
@@ -1,0 +1,126 @@
+import path from 'node:path';
+
+import {
+  defaultHost,
+  defaultSiteUrl,
+  getSeoOutputDir,
+  optionalEnv,
+  parseCliArgs,
+  readOptionalJson,
+  writeJson,
+} from './_shared.mjs';
+
+const args = parseCliArgs();
+const outputDir = getSeoOutputDir(args);
+const siteUrl = (args.site || process.env.PUBLIC_SITE_URL || defaultSiteUrl).replace(/\/$/, '');
+const host = new URL(siteUrl).host || defaultHost;
+const key = args.key || optionalEnv('INDEXNOW_KEY') || optionalEnv('BING_INDEXNOW_KEY');
+const keyLocation = args.keyLocation || optionalEnv('INDEXNOW_KEY_LOCATION', key ? `${siteUrl}/${key}.txt` : '');
+const dryRun = args['dry-run'] === 'true' || args.dryRun === 'true';
+const endpoint = args.endpoint || 'https://api.indexnow.org/indexnow';
+
+function splitUrls(value = '') {
+  return String(value)
+    .split(/[,\n]/)
+    .map((url) => url.trim())
+    .filter(Boolean);
+}
+
+function uniqueUrls(urls) {
+  return [...new Set(urls)].filter((url) => {
+    try {
+      const parsed = new URL(url);
+      return parsed.protocol === 'https:' && parsed.host === host;
+    } catch {
+      return false;
+    }
+  });
+}
+
+function loadIndexNowUrlsFromAhrefs() {
+  const artifactPath = args.input
+    ? path.resolve(args.input)
+    : path.join(outputDir, 'ahrefs-site-audit.json');
+  const artifact = readOptionalJson(artifactPath, null);
+  const details = artifact?.issueDetails || [];
+  const issue = details.find((item) => item.name === 'Pages to submit to IndexNow');
+  return {
+    artifactPath,
+    urls: (issue?.pages || []).map((page) => page.url).filter(Boolean),
+  };
+}
+
+async function submitIndexNow(urls) {
+  const body = {
+    host,
+    key,
+    keyLocation,
+    urlList: urls,
+  };
+
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  return {
+    status: response.status,
+    ok: response.ok,
+    text: await response.text(),
+  };
+}
+
+async function main() {
+  const generatedAt = new Date().toISOString();
+  const source = args.urls ? { artifactPath: null, urls: splitUrls(args.urls) } : loadIndexNowUrlsFromAhrefs();
+  const urls = uniqueUrls(source.urls);
+
+  const report = {
+    generatedAt,
+    endpoint,
+    siteUrl,
+    host,
+    sourceArtifact: source.artifactPath,
+    dryRun,
+    urlCount: urls.length,
+    urls,
+    status: 'pending',
+    response: null,
+    warnings: [],
+  };
+
+  if (urls.length === 0) {
+    report.status = 'skipped';
+    report.warnings.push('No same-host HTTPS URLs found for IndexNow submission.');
+  } else if (dryRun) {
+    report.status = 'dry-run';
+  } else if (!key || !keyLocation) {
+    report.status = 'misconfigured';
+    report.warnings.push('Set INDEXNOW_KEY and make the matching key file reachable, or pass --key and --keyLocation.');
+  } else {
+    report.response = await submitIndexNow(urls);
+    report.status = report.response.ok ? 'submitted' : 'failed';
+  }
+
+  const outputPath = path.join(outputDir, 'indexnow-submission.json');
+  writeJson(outputPath, report);
+
+  console.log(JSON.stringify({
+    ok: report.status === 'submitted' || report.status === 'dry-run',
+    status: report.status,
+    outputPath,
+    urlCount: report.urlCount,
+    warnings: report.warnings,
+    response: report.response,
+  }, null, 2));
+
+  if (report.status === 'failed' || report.status === 'misconfigured') {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -44,6 +44,8 @@ const tools = [
 ];
 
 const collections = [
+  { title: 'Free AI Prompt Library', description: 'Copy-ready prompts grouped for free AI tool tiers and repeatable workflows.', href: '/best/free-ai-prompts/' },
+  { title: 'Best AI Prompt Catalog', description: 'Start with the strongest prompts across every tool, category, and use case.', href: '/best/best-ai-prompts/' },
   { title: 'Best ChatGPT Prompts for Marketing', description: 'High-converting marketing prompts for campaigns, ad copy, and content strategy.', href: '/prompts/chatgpt/marketing/' },
   { title: 'AI Prompts for Teachers', description: 'Lesson plans, quizzes, rubrics, and differentiated instruction materials.', href: '/prompts/for/teachers/' },
   { title: 'Best Cursor Coding Prompts', description: 'Code generation, refactoring, debugging, and multi-file editing prompts.', href: '/prompts/cursor/coding/' },

--- a/src/pages/prompts/index.astro
+++ b/src/pages/prompts/index.astro
@@ -28,8 +28,8 @@ const categories = categoriesJson.map((c: any) => ({ id: c.id, name: c.name, slu
 ---
 
 <BaseLayout
-  title="Browse All AI Prompts"
-  description="Explore our curated collection of AI prompts for ChatGPT, Claude, Midjourney, and more. Filter by tool, category, and difficulty level."
+  title="AI Prompt Catalog | Browse Free Prompt Templates"
+  description="Explore a curated AI prompt catalog for ChatGPT, Claude, Midjourney, and more. Filter free prompt templates by tool, category, and difficulty level."
 >
   <Header slot="header" />
 
@@ -39,6 +39,26 @@ const categories = categoriesJson.map((c: any) => ({ id: c.id, name: c.name, slu
       <p class="mt-2 text-lg text-[var(--color-text-secondary)]">
         {prompts.length} curated prompts across {new Set(prompts.map(p => p.category)).size} categories
       </p>
+      <div class="mt-5 flex flex-wrap gap-3 text-sm">
+        <a
+          href="/best/free-ai-prompts/"
+          class="surface-solid-content rounded-full px-4 py-2 font-medium text-[var(--color-text-secondary)] transition-colors hover:text-[var(--color-accent)]"
+        >
+          Free AI prompt library
+        </a>
+        <a
+          href="/best/best-ai-prompts/"
+          class="surface-solid-content rounded-full px-4 py-2 font-medium text-[var(--color-text-secondary)] transition-colors hover:text-[var(--color-accent)]"
+        >
+          Best AI prompt catalog
+        </a>
+        <a
+          href="/guides/prompt-engineering-101/"
+          class="surface-solid-content rounded-full px-4 py-2 font-medium text-[var(--color-text-secondary)] transition-colors hover:text-[var(--color-accent)]"
+        >
+          Prompt engineering guide
+        </a>
+      </div>
     </div>
 
     <PromptFilter


### PR DESCRIPTION
## Summary
- add an IndexNow submission command that reads Ahrefs issue-detail URLs
- add internal links and metadata language for the free AI prompt library / AI prompt catalog cluster
- document slow-page triage and priority citation/backlink targets

## Verification
- npm run build
- npm run seo:submit:indexnow -- --dry-run=true
- git diff --check

## Notes
- npm run check is currently blocked by existing Convex generated-type and older TypeScript issues outside this diff.