### PR TITLE
fix(seo): replace prompt query links with category route

### DIFF
--- a/src/data/guides/midjourney-prompt-guide.md
+++ b/src/data/guides/midjourney-prompt-guide.md
@@ -402,4 +402,4 @@ Ready to actually make stuff? The library has dozens of image prompts across eve
 
 Every prompt ships with the full text, variable explanations, and notes on what to tweak.
 
-[Browse All Image Generation Prompts](/prompts/?type=image) | [Browse the Full Prompt Library](/prompts/)
+[Browse All Image Generation Prompts](/categories/image-generation/) | [Browse the Full Prompt Library](/prompts/)

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -104,7 +104,7 @@ const startHereResources = [
   {
     title: 'Image Prompt Browser',
     description: 'Jump straight into AI art, product photo, logo, thumbnail, and visual prompt examples.',
-    href: '/prompts/?type=image',
+    href: '/categories/image-generation/',
     label: 'Images',
   },
 ];

--- a/src/pages/prompts/index.astro
+++ b/src/pages/prompts/index.astro
@@ -40,7 +40,7 @@ const discoveryLinks = [
   {
     title: 'Image Generation Prompts',
     description: 'Browse AI art, logo, product photo, thumbnail, and visual prompt examples.',
-    href: '/prompts/?type=image',
+    href: '/categories/image-generation/',
   },
   {
     title: 'Prompt Templates',


### PR DESCRIPTION
## Summary
- Replace crawlable /prompts/?type=image links with /categories/image-generation/
- Update homepage, prompt index, and Midjourney guide links to use a static indexable route
- Keep the fix isolated from the larger dirty local worktree

## Search Console Evidence
- Page with redirect example: https://aipromptindex.io/prompts/?type=image
- Alternate page with proper canonical tag example: https://aipromptindex.io/prompts/?category=image-generation
- Both examples are query variants of /prompts/ discovered by Google, not sitemap URLs

## Validation
- rg -n "prompts/\?type=image|\?type=image|\?category=image-generation" src (no matches)
- git diff --check
- npm run build
- Generated sitemap check: 250 URLs, 0 query URLs, /categories/image-generation/ present
